### PR TITLE
Mv & cp commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/morgan": "^1.7.33",
     "@types/node": "^8.0.32",
     "body-parser": "^1.18.2",
+    "child_process": "^1.0.2",
     "express": "^4.16.1",
     "gulp": "^3.9.1",
     "gulp-typescript": "^3.2.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import * as express from 'express';
 import * as logger from 'morgan';
 import * as bodyParser from 'body-parser';
 import { Constants } from './constants';
+import * as Shell from './shell';
 
 const { lstatSync, readdirSync, readFile } = require('fs')
 const { join } = require('path')
@@ -99,6 +100,22 @@ class App {
         }).catch(err => this.onError(err, res))
     });
     this.express.use('/', router);
+
+    // 'mv' & 'cp' commands
+    router.post('/*', (req, res, next) => {
+      let path = `./${req.param('0') || ''}`
+      let cmd = req.body.cmd;
+      let dest = req.body.dest;
+      let command = `${cmd} ${path} ${dest}`;
+      console.log('Command to run: ' + command);
+      Shell.isEnabled(command)
+        .then(() => Shell.execSh(command))
+        .then((stdout) => {
+          res.send(true);
+        }).catch(err => {
+          res.status(500).send(err);
+        });
+    });
   }
 
   private onError(err, res) : void {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,21 +1,19 @@
 import * as express from 'express';
 import * as logger from 'morgan';
 import * as bodyParser from 'body-parser';
+import { Constants } from './constants';
 
 const { lstatSync, readdirSync, readFile } = require('fs')
 const { join } = require('path')
 
 const ENCODING = 'utf8'
-const errors = {
-  PATH_NOT_FOUND: 'Requested path not found'
-}
 
 const isDirectory = source => {
   return new Promise((resolve, reject) => {
     try {
       resolve(lstatSync(source).isDirectory())
     } catch(err) {
-      reject({ status: 404, err: errors.PATH_NOT_FOUND})
+      reject({ status: 404, err: Constants.ERRORS.PATH_NOT_FOUND})
     }
   })
 }
@@ -39,7 +37,7 @@ const getDirectoryContent = source => {
       content = readdirSync(source)
       resolve(content.map(name => join(source, name)))
     } catch(err) {
-      reject({ status: 404, msg: errors.PATH_NOT_FOUND })
+      reject({ status: 404, msg: Constants.ERRORS.PATH_NOT_FOUND })
     }
   })
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,9 @@
+export class Constants {
+  public static ERRORS = {
+    PATH_NOT_FOUND: 'Requested path not found',
+    CMD_MALFORMED: 'Err: command malformed',
+    WRONG_ARGS_NUMBER: 'Err: wrong args number',
+    MISSING_CMD: 'Err: missing command',
+    NOT_ALLOWED_CMD: 'Err: command not allowed'
+  }
+}

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -9,16 +9,19 @@ const contains = (container, contained) => {
 }
 
 export const isEnabled = command => {
-  if(!command) return Promise.reject(Constants.ERRORS.MISSING_CMD);
-  else if(!contains(command, SEPARATOR)) return Promise.reject(Constants.ERRORS.CMD_MALFORMED);
+  var err;
+  if(!command) err = Constants.ERRORS.MISSING_CMD;
+  else if(!contains(command, SEPARATOR)) err = Constants.ERRORS.CMD_MALFORMED;
   else {
     let split = command.split(SEPARATOR);
     let cmd = split && split.length ? split[0] : null;
     if(cmd && contains(ALLOWED_COMMANDS, cmd)) {
-        if(split.length != 3) return Promise.reject(Constants.ERRORS.WRONG_ARGS_NUMBER);
+        if(split.length != 3) err = Constants.ERRORS.WRONG_ARGS_NUMBER;
         else return Promise.resolve();
-    } else return Promise.reject(Constants.ERRORS.NOT_ALLOWED_CMD);
+    } else err = Constants.ERRORS.NOT_ALLOWED_CMD;
   }
+
+  return Promise.reject(err);
 }
 
 export const execSh = command => {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,0 +1,34 @@
+import { Constants } from './constants';
+import * as ps from 'child_process';
+
+const ALLOWED_COMMANDS = ['mv', 'cp'];
+const SEPARATOR = ' ';
+
+const contains = (container, contained) => {
+  return container.indexOf(contained) >= 0 ? true : false;
+}
+
+export const isEnabled = command => {
+  if(!command) return Promise.reject(Constants.ERRORS.MISSING_CMD);
+  else if(!contains(command, SEPARATOR)) return Promise.reject(Constants.ERRORS.CMD_MALFORMED);
+  else {
+    let split = command.split(SEPARATOR);
+    let cmd = split && split.length ? split[0] : null;
+    if(cmd && contains(ALLOWED_COMMANDS, cmd)) {
+        if(split.length != 3) return Promise.reject(Constants.ERRORS.WRONG_ARGS_NUMBER);
+        else return Promise.resolve();
+    } else return Promise.reject(Constants.ERRORS.NOT_ALLOWED_CMD);
+  }
+}
+
+export const execSh = command => {
+  return new Promise((resolve, reject) => {
+    ps.exec(command, (error, stdout, stderr) => {
+        if (error) {
+            console.log(`exec error: ${error}`);
+            reject(error);
+        } else resolve(stdout);
+    });
+  });
+}
+


### PR DESCRIPTION
I used `child_process` module for executing shell commands for handling `mv` and `cp` operations.

Concerning the API contract, I temporarily (open to discussion) used 
- `POST ${PATH}` (`PATH` being the source file/directory)
- Parameters:
  - `cmd` (`mv` or `cp` are the only allowed for the moment)
  - `dest` (destination path)

`curl` sample for moving `README.md` file to a `.tmp` directory:

```
curl -X POST \
  http://localhost:3000/README.md \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'cmd=cp&dest=.tmp%2Fmoved_file'
```